### PR TITLE
adding 'doSearchAlt(..)'

### DIFF
--- a/client-1/js/app.mjs
+++ b/client-1/js/app.mjs
@@ -83,14 +83,14 @@ function *runApp(viewContext) {
 	IOx.do(changePlatform,[ IOx.onEvent(platformsEl,"change") ])
 		.run(viewContext);
 
-	// VERSION 1: listen for clicks on the search button
+	// VERSION 1 (listen for clicks on the search button)
 	//
 	// note: ditto about `yield` vs `run()`
 	IOx.doEither(doSearch,[ IOx.onEvent(searchBtn,"click") ])
 		.run(viewContext);
 
 
-	// // VERSION 2: listen for clicks on the search button
+	// // VERSION 2 (listen for clicks on the search button)
 	// //
 	// // note: ditto about `yield` vs `run()`
 	// IOx.do(doSearchAlt,[ IOx.onEvent(searchBtn,"click") ])
@@ -131,7 +131,7 @@ function *changePlatform({ searchBtn }) {
 	);
 }
 
-// VERSION 1: `doSearch(..)` invoked with `doEither(..)`;
+// VERSION 1 (`doSearch(..)` invoked with `doEither(..)`)
 // Either:Left values throw, so error handling done with
 // `try..catch` style
 function *doSearch(viewContext) {
@@ -161,7 +161,7 @@ function *doSearch(viewContext) {
 
 
 // // ---------------------------------------------------
-// // VERSION 2: `doSearchAlt(..)` invoked with `do(..)`;
+// // VERSION 2 (`doSearchAlt(..)` invoked with `do(..)`)
 // // no automatic throwing of Either:Left, so uses
 // // fold(..) for success/error handling
 // function *doSearchAlt(viewContext) {

--- a/client-1/js/util.mjs
+++ b/client-1/js/util.mjs
@@ -36,7 +36,8 @@ function disableElement(el) { return IO(() => el.disabled = true); }
 function enableElement(el) { return IO(() => el.disabled = false); }
 
 function *apiGet(env,endpoint) {
-	let apiEndpointURL = `/api/${endpoint}`;
+	var apiEndpointURL = `/api/${endpoint}`;
+
 	try {
 		let res = yield fetch(apiEndpointURL);
 
@@ -50,7 +51,7 @@ function *apiGet(env,endpoint) {
 
 		return json.fold(
 			() => Either.Left(`API call failed: ${apiEndpointURL}`),
-			identity
+			res => Either.Right(res)
 		);
 	}
 	catch (err) {

--- a/client-1/js/util.mjs
+++ b/client-1/js/util.mjs
@@ -35,6 +35,7 @@ function appendElement(parentEl,childEl) { return IO(() => parentEl.appendChild(
 function disableElement(el) { return IO(() => el.disabled = true); }
 function enableElement(el) { return IO(() => el.disabled = false); }
 
+// returns an Either
 function *apiGet(env,endpoint) {
 	var apiEndpointURL = `/api/${endpoint}`;
 


### PR DESCRIPTION
As discussed, here's an alternate version of `doSearch(..)` that shows using `fold(..)` instead of `try..catch`.

+@DrBoolean 